### PR TITLE
feat: support explicit parameter naming in YAML rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # pandas-conditional-validator
+
+Herramienta ligera para validar `DataFrame` de pandas en base a reglas
+definidas en un archivo YAML. Las reglas pueden ser globales o aplicarse
+únicamente a un parámetro (valor de la columna `parametro`).
+
+## Configuración de reglas
+
+Las reglas se definen en un archivo YAML. A partir de esta versión la sección
+`parametros` acepta una **lista** de objetos, donde cada entrada especifica el
+nombre del parámetro de forma explícita mediante la clave `name` (o `parametro`).
+Esto evita la ambigüedad sobre si el identificador corresponde a una columna o
+al valor de un parámetro dentro del `DataFrame`.
+
+```yaml
+parametros:
+  - name: Relacion_NP
+    condition:
+      type: conditional
+      if:
+        operator: AND
+        conditions:
+          - type: greater_than
+            col: nitrógeno
+            value: 5
+          - operator: OR
+            conditions:
+              - type: less_than
+                col: fósforo
+                value: 3
+              - type: between
+                col: fósforo
+                min: 4
+                max: 6
+      then:
+        type: less_than
+        col: valor
+        value: 2
+
+_global:
+  - type: between
+    col: temperatura
+    min: 0
+    max: 35
+```
+
+La estructura anterior sigue siendo compatible con la sintaxis previa basada en
+diccionarios, por lo que los archivos existentes continúan funcionando sin
+modificaciones.

--- a/df_rule_validator/rules_schema.py
+++ b/df_rule_validator/rules_schema.py
@@ -313,20 +313,40 @@ class RulesConfig(BaseModel):
         metadata_obj = ConfigMetadata(**metadata) if metadata else None
 
         # Procesar parámetros
-        params = raw.get('parametros') or {}
+        params_raw = raw.get('parametros') or {}
         validated_params = {}
-        for name, rule_dict in params.items():
-            # Extraer metadata de la regla paramétrica
-            rule_metadata = rule_dict.get('metadata')
-            rule_metadata_obj = ValidationMetadata(**rule_metadata) if rule_metadata else None
-            
-            # Procesar condición
-            cond = rule_dict.get('condition')
-            validated = RulesConfig._validate_condition(cond)
-            validated_params[name] = ParametricRule(
-                condition=validated,
-                metadata=rule_metadata_obj
-            )
+
+        # Nueva estructura flexible: permite una lista de reglas con nombre explícito
+        if isinstance(params_raw, list):
+            for item in params_raw:
+                name = item.get('name') or item.get('parametro') or item.get('param')
+                if not name:
+                    raise ValueError("Cada regla paramétrica debe incluir 'name' o 'parametro'")
+
+                rule_metadata = item.get('metadata')
+                rule_metadata_obj = ValidationMetadata(**rule_metadata) if rule_metadata else None
+
+                cond = item.get('condition')
+                validated = RulesConfig._validate_condition(cond)
+                validated_params[name] = ParametricRule(
+                    condition=validated,
+                    metadata=rule_metadata_obj
+                )
+        elif isinstance(params_raw, dict):
+            for name, rule_dict in params_raw.items():
+                # Extraer metadata de la regla paramétrica
+                rule_metadata = rule_dict.get('metadata')
+                rule_metadata_obj = ValidationMetadata(**rule_metadata) if rule_metadata else None
+
+                # Procesar condición
+                cond = rule_dict.get('condition')
+                validated = RulesConfig._validate_condition(cond)
+                validated_params[name] = ParametricRule(
+                    condition=validated,
+                    metadata=rule_metadata_obj
+                )
+        else:
+            raise ValueError("'parametros' debe ser un objeto o una lista de reglas")
 
         # Procesar reglas globales
         globs = raw.get('_global') or []

--- a/examples/rules_example.yaml
+++ b/examples/rules_example.yaml
@@ -1,5 +1,5 @@
 parametros:
-  Relacion_NP:
+  - name: Relacion_NP
     condition:
       type: conditional
       if:

--- a/examples/rules_parametric.yaml
+++ b/examples/rules_parametric.yaml
@@ -1,5 +1,5 @@
 parametros:
-  Relacion_NP:
+  - name: Relacion_NP
     condition:
       type: conditional
       if:
@@ -22,7 +22,7 @@ parametros:
         col: "{target_column}"  # Parámetro para columna objetivo
         value: "{target_threshold}"
 
-  Temperatura_Rango:
+  - name: Temperatura_Rango
     condition:
       type: between
       col: "{temperature_column}"  # Parámetro para columna de temperatura


### PR DESCRIPTION
## Summary
- allow `parametros` to be defined as an explicit list of named rules
- document new YAML structure and provide updated examples

## Testing
- `python test_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d1f222788320a08008464877f8ae