### PR TITLE
feat: make parameter column configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Herramienta ligera para validar `DataFrame` de pandas en base a reglas
 definidas en un archivo YAML. Las reglas pueden ser globales o aplicarse
-únicamente a un parámetro (valor de la columna `parametro`).
+únicamente a un parámetro (valor de una columna configurable mediante
+el parámetro `param_col`, que por defecto apunta a la columna
+`parametro`).
 
 ## Configuración de reglas
 
@@ -47,3 +49,19 @@ _global:
 La estructura anterior sigue siendo compatible con la sintaxis previa basada en
 diccionarios, por lo que los archivos existentes continúan funcionando sin
 modificaciones.
+
+## Uso de `validate_dataframe`
+
+Al momento de validar un `DataFrame` se puede indicar explícitamente la
+columna que contiene el nombre del parámetro mediante el argumento
+`param_col`:
+
+```python
+from df_rule_validator.validator import validate_dataframe
+
+fails, df_validado = validate_dataframe(df, rules, param_col="mi_columna")
+```
+
+Si no se proporciona `param_col`, la función utilizará la columna
+`parametro` por defecto.
+

--- a/df_rule_validator/logger.py
+++ b/df_rule_validator/logger.py
@@ -1,14 +1,15 @@
 from datetime import datetime
+import json
 
 class ValidationLogger:
     def __init__(self, log_file=None):
         self.log_file = log_file
         self.entries = []
 
-    def log_failure(self, parametro, row, rule):
+    def log_failure(self, parametro, row, rule, param_col="parametro"):
         self.entries.append({
             "timestamp": datetime.utcnow().isoformat(),
-            "parametro": parametro,
+            param_col: parametro,
             "row_data": row,
             "rule_failed": rule
         })

--- a/df_rule_validator/validator.py
+++ b/df_rule_validator/validator.py
@@ -46,14 +46,14 @@ def eval_condition(df, cond):
         else:
             raise ValueError(f"Tipo de condición no soportada: {cond['type']}")
 
-def validate_dataframe(df: pd.DataFrame, rules: RulesConfig, action="log_only", log_file=None):
+def validate_dataframe(df: pd.DataFrame, rules: RulesConfig, action="log_only", log_file=None, param_col="parametro"):
     logger = ValidationLogger(log_file)
     fails_list = []
 
     # Validar por parámetro
     if rules.parametros:
         for param, rule in rules.parametros.items():
-            subset = df[df["parametro"] == param]
+            subset = df[df[param_col] == param]
             mask_if, mask_then = None, None
 
             if rule["condition"]["type"] == "conditional":
@@ -65,7 +65,7 @@ def validate_dataframe(df: pd.DataFrame, rules: RulesConfig, action="log_only", 
                 fails = subset[~mask]
 
             for _, row in fails.iterrows():
-                logger.log_failure(param, row.to_dict(), rule)
+                logger.log_failure(param, row.to_dict(), rule, param_col)
                 fails_list.append(row.name)
 
     if rules._global:
@@ -73,7 +73,7 @@ def validate_dataframe(df: pd.DataFrame, rules: RulesConfig, action="log_only", 
             mask = eval_condition(df, rule)
             fails = df[~mask]
             for _, row in fails.iterrows():
-                logger.log_failure(row.get("parametro"), row.to_dict(), rule)
+                logger.log_failure(row.get(param_col), row.to_dict(), rule, param_col)
                 fails_list.append(row.name)
 
     if action == "drop_rows":


### PR DESCRIPTION
## Summary
- allow choosing which column contains rule parameters in `validate_dataframe`
- log failures using the chosen column name instead of hardcoding `parametro`
- document how to supply a custom parameter column

## Testing
- `python test_validation.py`
- `python - <<'PY'
from types import SimpleNamespace
import yaml
from df_rule_validator.validator import validate_dataframe
import pandas as pd

rules_dict = yaml.safe_load(open('examples/rules_example.yaml'))
rules = SimpleNamespace(
    parametros={item['name']: item for item in rules_dict['parametros']},
    _global=rules_dict.get('_global')
)

df = pd.read_csv('examples/data_example.csv')
df = df.rename(columns={'parametro': 'param_name'})
fails, df_val = validate_dataframe(df, rules, param_col='param_name')
print('fails', fails)
print(df_val.head())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6890d5731f1083209cb00782474004f5