### PR TITLE
Requiere columna de parámetro explícita y actualiza ejemplos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,19 @@
 
 Herramienta ligera para validar `DataFrame` de pandas en base a reglas
 definidas en un archivo YAML. Las reglas pueden ser globales o aplicarse
-únicamente a un parámetro (valor de una columna configurable mediante
-el parámetro `param_col`, que por defecto apunta a la columna
-`parametro`).
+únicamente a un parámetro (valor de una columna cuyo nombre debe
+indicarse mediante el argumento `param_col`).
 
 ## Configuración de reglas
 
-Las reglas se definen en un archivo YAML. A partir de esta versión la sección
-`parametros` acepta una **lista** de objetos, donde cada entrada especifica el
-nombre del parámetro de forma explícita mediante la clave `name` (o `parametro`).
-Esto evita la ambigüedad sobre si el identificador corresponde a una columna o
-al valor de un parámetro dentro del `DataFrame`.
+Las reglas se definen en un archivo YAML. La sección `parametros` utiliza un
+**objeto** donde cada clave corresponde al nombre de la regla mayor. Este nombre
+debe coincidir con los valores de la columna indicada por `param_col` en el
+`DataFrame`.
 
 ```yaml
 parametros:
-  - name: Relacion_NP
+  Relacion_NP:
     condition:
       type: conditional
       if:
@@ -46,13 +44,12 @@ _global:
     max: 35
 ```
 
-La estructura anterior sigue siendo compatible con la sintaxis previa basada en
-diccionarios, por lo que los archivos existentes continúan funcionando sin
-modificaciones.
+Cada clave dentro de `parametros` representa una regla que se aplicará a las
+filas cuyo valor en la columna de parámetros coincida con ella.
 
 ## Uso de `validate_dataframe`
 
-Al momento de validar un `DataFrame` se puede indicar explícitamente la
+Al momento de validar un `DataFrame` se debe indicar explícitamente la
 columna que contiene el nombre del parámetro mediante el argumento
 `param_col`:
 
@@ -62,6 +59,5 @@ from df_rule_validator.validator import validate_dataframe
 fails, df_validado = validate_dataframe(df, rules, param_col="mi_columna")
 ```
 
-Si no se proporciona `param_col`, la función utilizará la columna
-`parametro` por defecto.
+`param_col` es obligatorio; la función no define un valor por defecto.
 

--- a/demo.py
+++ b/demo.py
@@ -9,6 +9,7 @@ df = pd.read_csv("examples/data_example.csv")
 fails, cleaned_df = validate_dataframe(
     df,
     rules,
+    param_col="parametro",
     action="drop_rows",
     log_file="validation_log.jsonl"
 )

--- a/df_rule_validator/logger.py
+++ b/df_rule_validator/logger.py
@@ -6,7 +6,7 @@ class ValidationLogger:
         self.log_file = log_file
         self.entries = []
 
-    def log_failure(self, parametro, row, rule, param_col="parametro"):
+    def log_failure(self, parametro, row, rule, param_col):
         self.entries.append({
             "timestamp": datetime.utcnow().isoformat(),
             param_col: parametro,

--- a/df_rule_validator/validator.py
+++ b/df_rule_validator/validator.py
@@ -46,9 +46,12 @@ def eval_condition(df, cond):
         else:
             raise ValueError(f"Tipo de condición no soportada: {cond['type']}")
 
-def validate_dataframe(df: pd.DataFrame, rules: RulesConfig, action="log_only", log_file=None, param_col="parametro"):
+def validate_dataframe(df: pd.DataFrame, rules: RulesConfig, action="log_only", log_file=None, param_col=None):
     logger = ValidationLogger(log_file)
     fails_list = []
+
+    if param_col is None:
+        raise ValueError("Debe especificarse 'param_col' con el nombre de la columna de parámetros")
 
     # Validar por parámetro
     if rules.parametros:

--- a/examples/rules_example.yaml
+++ b/examples/rules_example.yaml
@@ -1,5 +1,5 @@
 parametros:
-  - name: Relacion_NP
+  Relacion_NP:
     condition:
       type: conditional
       if:
@@ -21,6 +21,7 @@ parametros:
         type: less_than
         col: valor
         value: 2
+
 _global:
   - type: between
     col: temperatura

--- a/examples/rules_parametric.yaml
+++ b/examples/rules_parametric.yaml
@@ -1,5 +1,5 @@
 parametros:
-  - name: Relacion_NP
+  Relacion_NP:
     condition:
       type: conditional
       if:
@@ -22,7 +22,7 @@ parametros:
         col: "{target_column}"  # Parámetro para columna objetivo
         value: "{target_threshold}"
 
-  - name: Temperatura_Rango
+  Temperatura_Rango:
     condition:
       type: between
       col: "{temperature_column}"  # Parámetro para columna de temperatura


### PR DESCRIPTION
## Summary
- Documentación y ejemplos YAML ahora definen reglas como claves dentro de `parametros` y exigen indicar la columna de parámetros mediante `param_col`.
- El validador y el logger requieren `param_col` explícito, eliminando el valor por defecto `parametro`.
- Script de demostración actualizado para especificar la columna de parámetros.

## Testing
- `python test_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d703902c8320971f8a3be94d6580